### PR TITLE
[Resolves #4] 기본 도메인 작성

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/config/BaseTimeConfig.java
+++ b/src/main/java/org/swmaestro/mohaeng/config/BaseTimeConfig.java
@@ -1,0 +1,17 @@
+package org.swmaestro.mohaeng.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseTimeConfig {
+
+    @PostConstruct
+    public void setSeoulTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Admin.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Admin.java
@@ -1,0 +1,38 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "admin_id", nullable = false)
+    private String adminId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(name = "last_login", nullable = false)
+    private LocalDateTime lastLogin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/BaseTimeEntity.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/BlackList.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/BlackList.java
@@ -1,0 +1,29 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.user.User;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlackList extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "blocked_feature", nullable = false)
+    private String blockedFeature;
+
+    @Column(name = "blocked_reason", nullable = false)
+    private String blockedReason;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/CommonCode.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/CommonCode.java
@@ -1,0 +1,32 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+public class CommonCode {
+
+    @Id
+    private String code;
+
+    @Column
+    private String codeName;
+
+    @Column
+    private String codeDescription;
+
+    @Column
+    private String codeType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_code")
+    private CommonCode parentCode;
+
+    @OneToMany(mappedBy = "parentCode", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommonCode> childCodes = new ArrayList<>();
+
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Favorite.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Favorite.java
@@ -1,0 +1,39 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.event.Event;
+import org.swmaestro.mohaeng.domain.user.User;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "favorite_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Builder
+    public Favorite(User user, Event event) {
+        this.user = user;
+        this.event = event;
+    }
+
+    public void removeUser() {
+        this.user = null;
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Location.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Location.java
@@ -1,0 +1,49 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.user.User;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Location extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(name = "latitude", nullable = false)
+    private String latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private String longitude;
+
+    @Column(name = "is_used", nullable = false)
+    private Boolean isUsed;
+
+    @Builder
+    public Location(User user, String name, String address, String latitude, String longitude, Boolean isUsed) {
+        this.user = user;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.isUsed = isUsed;
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Owner.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Owner.java
@@ -1,0 +1,33 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.shop.ShopDetail;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Owner extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "owner_id", nullable = false)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "shop_detail_id", nullable = false)
+    private ShopDetail shopDetail;
+
+    @OneToMany
+    @JoinColumn(name = "owner_id")
+    private List<Payment> payments = new ArrayList<>();
+
+    void addPayment(Payment payment) {
+        payments.add(payment);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Payment.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Payment.java
@@ -1,0 +1,33 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id", nullable = false)
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private Owner owner;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "payment_id")
+    private List<PaymentProduct> paymentProducts = new ArrayList<>();
+
+    void addPaymentProduct(PaymentProduct paymentProduct) {
+        paymentProducts.add(paymentProduct);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/PaymentProduct.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/PaymentProduct.java
@@ -1,0 +1,23 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_product_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Role.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Role.java
@@ -1,0 +1,16 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER", "일반 사용자"),
+    OWNER("ROLE_OWNER", "자영업자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/Status.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Status.java
@@ -1,0 +1,15 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public enum Status {
+    ACTIVE("active"),
+    INACTIVE("inactive");
+
+    private String value;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/View.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/View.java
@@ -1,0 +1,31 @@
+package org.swmaestro.mohaeng.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.event.Event;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class View {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "view_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "view_date_time", nullable = false)
+    private LocalDateTime viewDateTime;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/CreatedBy.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/CreatedBy.java
@@ -1,0 +1,5 @@
+package org.swmaestro.mohaeng.domain.event;
+
+public enum CreatedBy {
+    CRAWLER, USER, OWNER
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/Event.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/Event.java
@@ -1,0 +1,90 @@
+package org.swmaestro.mohaeng.domain.event;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.BaseTimeEntity;
+import org.swmaestro.mohaeng.domain.Status;
+import org.swmaestro.mohaeng.domain.shop.Shop;
+import org.swmaestro.mohaeng.domain.View;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
+
+    @OneToMany(mappedBy = "event")
+    private List<View> views = new ArrayList<>();
+
+    @Column(name = "category_code", nullable = false, length = 45)
+    private String categoryCode;
+
+    @Enumerated(EnumType.STRING)
+    private EventDetails eventDetails;
+
+    @Column(name = "event_regular_price", nullable = false)
+    private int regularPrice;
+
+    @Column(name = "event_discount_price")
+    private int discountPrice;
+
+    @Column(name = "event_name", nullable = false)
+    private String name;
+
+    @Column(name = "event_description", nullable = false)
+    private String description;
+
+    @Column(name = "event_image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "event_start_date", nullable = false)
+    private String startDate;
+
+    @Column(name = "event_end_date", nullable = false)
+    private String endDate;
+
+    @Column(name = "event_start_time")
+    private String startTime;
+
+    @Column(name = "event_end_time")
+    private String endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_created_by", nullable = false)
+    private CreatedBy createdBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_status", nullable = false)
+    private Status status;
+
+    @Builder
+    public Event(Shop shop, String categoryCode, EventDetails eventDetails, int regularPrice, int discountPrice, String name, String description, String imageUrl, String startDate, String endDate, String startTime, String endTime, CreatedBy createdBy, Status status) {
+        this.shop = shop;
+        this.categoryCode = categoryCode;
+        this.eventDetails = eventDetails;
+        this.regularPrice = regularPrice;
+        this.discountPrice = discountPrice;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.createdBy = createdBy;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/EventDetails.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/EventDetails.java
@@ -1,0 +1,5 @@
+package org.swmaestro.mohaeng.domain.event;
+
+public enum EventDetails {
+    ONE_PLUS_ONE, TWO_PLUS_ONE, PRICE_DISCOUNT, COUPON, ETC
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/shop/Shop.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/shop/Shop.java
@@ -1,0 +1,41 @@
+package org.swmaestro.mohaeng.domain.shop;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.event.Event;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Shop {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shop_id", nullable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ShopType shopType;
+
+    @Column(name = "brand_code", nullable = false, length = 45)
+    private String brandCode;
+
+    @OneToMany(mappedBy = "shop")
+    private List<Event> events = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop")
+    private List<ShopDetail> shopDetails = new ArrayList<>();
+
+    public void addEvent(Event event) {
+        this.events.add(event);
+    }
+
+    public void addShopDetail(ShopDetail shopDetail) {
+        this.shopDetails.add(shopDetail);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/shop/ShopDetail.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/shop/ShopDetail.java
@@ -1,0 +1,46 @@
+package org.swmaestro.mohaeng.domain.shop;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.BaseTimeEntity;
+import org.swmaestro.mohaeng.domain.Status;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShopDetail extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shop_detail_id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
+
+    @Column(name = "shop_name", nullable = false)
+    private String name;
+
+    @Column(name = "shop_address", nullable = false)
+    private String address;
+
+    @Column(name = "shop_latitude", nullable = false)
+    private String latitude;
+
+    @Column(name = "shop_longitude", nullable = false)
+    private String longitude;
+
+    @Column(name = "shop_phone", nullable = true)
+    private String phone;
+
+    @Column(name = "shop_image_url", nullable = true)
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/shop/ShopType.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/shop/ShopType.java
@@ -1,0 +1,5 @@
+package org.swmaestro.mohaeng.domain.shop;
+
+public enum ShopType {
+    FRANCHISE, EACH
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/user/User.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/user/User.java
@@ -1,0 +1,85 @@
+package org.swmaestro.mohaeng.domain.user;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.swmaestro.mohaeng.domain.BaseTimeEntity;
+import org.swmaestro.mohaeng.domain.Location;
+import org.swmaestro.mohaeng.domain.Role;
+import org.swmaestro.mohaeng.domain.Status;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "`user`")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, unique=true)
+    private String email;
+
+    @Column(name = "nick_name", nullable = false)
+    private String nickName;
+
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @OneToMany
+    @JoinColumn(name = "user_id")
+    private List<Location> locations = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @Builder
+    public User(String email, String nickName, String provider, String providerId, String imageUrl, Status status, Role role) {
+        this.email = email;
+        this.nickName = nickName;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.imageUrl = imageUrl;
+        this.status = status;
+        this.role = role;
+    }
+
+    public static User createUser(String email, String nickname, String provider, String providerId, String imageUrl) {
+        return User.builder()
+                .email(email)
+                .nickName(nickname)
+                .provider(provider)
+                .providerId(providerId)
+                .imageUrl(imageUrl)
+                .status(Status.ACTIVE)
+                .role(Role.USER)
+                .build();
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+
+    public void addLocation(Location location) {
+        this.locations.add(location);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/AdminRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/AdminRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.Admin;
+
+public interface AdminRepository extends JpaRepository<Admin, String> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/BlackListRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/BlackListRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.BlackList;
+
+public interface BlackListRepository extends JpaRepository<BlackList, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/CommonCodeRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/CommonCodeRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.CommonCode;
+
+public interface CommonCodeRepository extends JpaRepository<CommonCode, String> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/FavoriteRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/FavoriteRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.Favorite;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/LocationRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/LocationRepository.java
@@ -1,0 +1,9 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.Location;
+
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/OwnerRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/OwnerRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.Owner;
+
+public interface OwnerRepository extends JpaRepository<Owner, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/PaymentProductRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/PaymentProductRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.PaymentProduct;
+
+public interface PaymentProductRepository extends JpaRepository<PaymentProduct, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/PaymentRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/ShopDetailRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/ShopDetailRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.shop.ShopDetail;
+
+public interface ShopDetailRepository extends JpaRepository<ShopDetail, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/ShopRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/ShopRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.shop.Shop;
+
+public interface ShopRepository extends JpaRepository<Shop, Long> {
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/UserRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.swmaestro.mohaeng.domain.user.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByEmail(String email);
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/ViewRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/ViewRepository.java
@@ -1,0 +1,7 @@
+package org.swmaestro.mohaeng.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.mohaeng.domain.View;
+
+public interface ViewRepository extends JpaRepository<View, Long> {
+}


### PR DESCRIPTION
## 작업 목록
- [x] 기본 도메인 작성

## 세부 내용
- Entity Column 명세 및 관계 설정
- Entity별 Repository 작성
<img width="829" alt="스크린샷 2023-08-29 오후 4 13 15" src="https://github.com/SWM-Overclock/MoHaeng-BE/assets/89470205/0a237020-c631-49da-afb1-8737986bc608">

- Owner Entity는 기본적인 관계 설정만 진행 (추후 필요한 컬럼 다시 명세)

## 논의 사항
- 공통 코드 테이블 vs Enum 사용하는 방식
    - Enum 사용하는 방식은 확장성이 다소 떨어져 공통 코드 테이블 사용
    - 공통 코드 엔티티와 비즈니스 엔티티는 연관 관계 매핑 하지 않고 CommonCodeService를 이용해 추후 조회하는 방식으로 진행
- View Entity, Event Entity 관계 설정
    - 양방향 관계로 설정
    - Event에서 View 목록 가져오는 것 필요

## 연결된 이슈
- #4 