### PR TITLE
[Resolves #47] 리프레시 토큰을 사용한 액세스 토큰 갱신 기능 구현

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/component/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/swmaestro/mohaeng/component/jwt/JwtTokenProvider.java
@@ -42,8 +42,7 @@ public class JwtTokenProvider {
         String generatedString = new String(array, StandardCharsets.UTF_8);
         String refreshToken = createToken(generatedString, refreshTokenValidityInMilliseconds);
 
-        redisService.setDataWithExpiration(userEmail, refreshToken, refreshTokenValidityInMilliseconds);
-
+        redisService.setDataWithExpiration(refreshToken, userEmail, refreshTokenValidityInMilliseconds);
         return refreshToken;
     }
 
@@ -91,7 +90,8 @@ public class JwtTokenProvider {
             throw new RuntimeException("유효하지 않은 리프레쉬 토큰 입니다");
         }
 
-        String userEmail = redisService.getEmailByRefreshToken(refreshToken);
+        String userEmail = redisService.getData(refreshToken);
+        log.info("userEmail: {}", userEmail);
         if (!redisService.validateToken(userEmail, refreshToken)) {
             throw new RuntimeException("유효하지 않은 리프레쉬 토큰 입니다");
         }

--- a/src/main/java/org/swmaestro/mohaeng/controller/AuthController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/AuthController.java
@@ -1,0 +1,25 @@
+package org.swmaestro.mohaeng.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.swmaestro.mohaeng.component.jwt.JwtTokenProvider;
+import org.swmaestro.mohaeng.dto.TokenRequest;
+import org.swmaestro.mohaeng.dto.TokenResponse;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissueToken(@RequestBody TokenRequest tokenRequest) {
+        log.info("refreshToken: {}", tokenRequest.getRefreshToken());
+        String newAccessToken = jwtTokenProvider.reissueAccessToken(tokenRequest.getRefreshToken());
+        return ResponseEntity.ok(new TokenResponse(newAccessToken));
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/controller/AuthController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/AuthController.java
@@ -16,7 +16,7 @@ public class AuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    @PostMapping("/reissue")
+    @PostMapping("/token-reissue")
     public ResponseEntity<?> reissueToken(@RequestBody TokenRequest tokenRequest) {
         log.info("refreshToken: {}", tokenRequest.getRefreshToken());
         String newAccessToken = jwtTokenProvider.reissueAccessToken(tokenRequest.getRefreshToken());

--- a/src/main/java/org/swmaestro/mohaeng/dto/TokenRequest.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/TokenRequest.java
@@ -1,0 +1,15 @@
+package org.swmaestro.mohaeng.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class TokenRequest {
+
+    @NotBlank(message = "Refresh Token을 입력해주세요.")
+    String refreshToken;
+}

--- a/src/main/java/org/swmaestro/mohaeng/dto/TokenResponse.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/TokenResponse.java
@@ -1,0 +1,15 @@
+package org.swmaestro.mohaeng.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+
+    public TokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/service/RedisService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/RedisService.java
@@ -26,11 +26,7 @@ public class RedisService {
     }
 
     public boolean validateToken(String userEmail, String refreshToken) {
-        String storedToken = getData(userEmail);
-        return refreshToken.equals(storedToken);
-    }
-
-    public String getEmailByRefreshToken(String refreshToken) {
-        return (String) redisTemplate.opsForValue().get(refreshToken);
+        String storedEmail = getData(refreshToken);
+        return userEmail.equals(storedEmail);
     }
 }


### PR DESCRIPTION
## 작업 목록
- [x] AuthController에 리프레시 토큰을 사용한 액세스 토큰 재발급 기능을 구현할 필요가 있습니다. 이 기능은 사용자가 만료된 액세스 토큰을 갱신할 수 있도록 하며, 보안을 강화하는 동시에 사용자 경험을 개선

## 세부 내용
-  AuthController에 ("/token-reissue)를 통해 리프레시 토큰을 받아 새 액세스 토큰을 발급하는 엔드포인트를 추가
- TokenRequest: Refresh Token Request DTO. @notblank 어노테이션을 사용하여 Refresh Token의 필수 입력을 보장
- TokenResponse: 새로 발급된 액세스 토큰을 담을 Response DTO.

## 논의 사항

## 연결된 이슈
- #47 