### PR TITLE
[Resolves #58] 주변 행사 상점 조회 기능 구현

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/config/CustomH2Functions.java
+++ b/src/main/java/org/swmaestro/mohaeng/config/CustomH2Functions.java
@@ -1,0 +1,34 @@
+package org.swmaestro.mohaeng.config;
+
+public class CustomH2Functions {
+
+    public static String createPoint(double longitude, double latitude) {
+        return String.format("POINT(%f %f)", longitude, latitude);
+    }
+
+    public static double h2DistanceSphere(String point1, String point2) {
+        double[] latLon1 = extractLatLonFromPoint(point1);
+        double[] latLon2 = extractLatLonFromPoint(point2);
+        return haversine(latLon1[1], latLon1[0], latLon2[1], latLon2[0]);
+    }
+
+    private static double[] extractLatLonFromPoint(String point) {
+        String[] parts = point.split("[ ()]+");
+        return new double[]{Double.parseDouble(parts[1]), Double.parseDouble(parts[2])};
+    }
+
+    private static double haversine(double lon1, double lat1, double lon2, double lat2) {
+        final int R = 6371; // Radius of the earth in kilometers
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double distance = R * c * 1000; // convert to meters
+
+        distance = Math.pow(distance, 2);
+
+        return Math.sqrt(distance);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/config/DatabaseConfig.java
+++ b/src/main/java/org/swmaestro/mohaeng/config/DatabaseConfig.java
@@ -1,0 +1,30 @@
+package org.swmaestro.mohaeng.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+@RequiredArgsConstructor
+@Component
+@Profile("local")
+public class DatabaseConfig {
+
+    private final DataSource dataSource;
+
+    @PostConstruct
+    public void initDb() {
+        try (Connection conn = dataSource.getConnection();
+            Statement stat = conn.createStatement()) {
+            stat.execute("CREATE ALIAS IF NOT EXISTS point FOR \"org.swmaestro.mohaeng.config.CustomH2Functions.createPoint\"");
+            stat.execute("CREATE ALIAS IF NOT EXISTS ST_DISTANCE_SPHERE FOR \"org.swmaestro.mohaeng.config.CustomH2Functions.h2DistanceSphere\"");
+        } catch (Exception e) {
+            throw new RuntimeException("Error initializing custom H2 functions", e);
+        }
+    }
+
+}

--- a/src/main/java/org/swmaestro/mohaeng/controller/ShopDetailController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/ShopDetailController.java
@@ -1,0 +1,32 @@
+package org.swmaestro.mohaeng.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swmaestro.mohaeng.domain.user.auth.CustomUserDetails;
+import org.swmaestro.mohaeng.dto.shop.ShopDetailListRequestDto;
+import org.swmaestro.mohaeng.service.ShopDetailService;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shops")
+public class ShopDetailController {
+
+    private final ShopDetailService shopDetailService;
+
+    @GetMapping("/nearby")
+    public ResponseEntity<List<ShopDetailListRequestDto>> getNearbyShopDetail(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        log.info("Fetching nearby shops for user ID: {}", userId);
+        List<ShopDetailListRequestDto> shopDetails = shopDetailService.getShopDetailsNearBy(userId);
+        log.info("Number of shops found: {}", shopDetails.size());
+        return ResponseEntity.ok(shopDetails);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailListRequestDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailListRequestDto.java
@@ -1,0 +1,38 @@
+package org.swmaestro.mohaeng.dto.shop;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.swmaestro.mohaeng.domain.shop.ShopDetail;
+import org.swmaestro.mohaeng.domain.shop.ShopType;
+
+@Getter
+public class ShopDetailListRequestDto {
+
+    private final Long id;
+    private final ShopType shopType;
+    private final String brandCode;
+    private final double latitude;
+    private final double longitude;
+    private final String imageUrl;
+
+    @Builder
+    public ShopDetailListRequestDto(Long id, ShopType shopType, String brandCode, double latitude, double longitude, String imageUrl) {
+        this.id = id;
+        this.shopType = shopType;
+        this.brandCode = brandCode;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.imageUrl = imageUrl;
+    }
+
+    public static ShopDetailListRequestDto of(ShopDetail shopDetail) {
+        return ShopDetailListRequestDto.builder()
+                .id(shopDetail.getId())
+                .shopType(shopDetail.getShop().getShopType())
+                .brandCode(shopDetail.getShop().getBrandCode())
+                .latitude(shopDetail.getLatitude())
+                .longitude(shopDetail.getLongitude())
+                .imageUrl(shopDetail.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/ShopDetailRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/ShopDetailRepository.java
@@ -12,7 +12,8 @@ public interface ShopDetailRepository extends JpaRepository<ShopDetail, Long> {
     @Query(value = "SELECT * FROM shop_detail " +
             "WHERE ST_DISTANCE_SPHERE(" +
             "point(shop_longitude, shop_latitude), " +
-            "point(:longitude, :latitude)) <= :radius",
+            "point(:longitude, :latitude)) <= :radius" +
+            "AND status = 'ACTIVE'",
             nativeQuery = true)
     List<ShopDetail> findShopsWithinRadius(@Param("longitude") double longitude, @Param("latitude") double latitude, @Param("radius") double radius);
 }

--- a/src/main/java/org/swmaestro/mohaeng/repository/ShopDetailRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/ShopDetailRepository.java
@@ -1,7 +1,18 @@
 package org.swmaestro.mohaeng.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.swmaestro.mohaeng.domain.shop.ShopDetail;
 
+import java.util.List;
+
 public interface ShopDetailRepository extends JpaRepository<ShopDetail, Long> {
+
+    @Query(value = "SELECT * FROM shop_detail " +
+            "WHERE ST_DISTANCE_SPHERE(" +
+            "point(shop_longitude, shop_latitude), " +
+            "point(:longitude, :latitude)) <= :radius",
+            nativeQuery = true)
+    List<ShopDetail> findShopsWithinRadius(@Param("longitude") double longitude, @Param("latitude") double latitude, @Param("radius") double radius);
 }

--- a/src/main/java/org/swmaestro/mohaeng/service/ShopDetailService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/ShopDetailService.java
@@ -1,0 +1,44 @@
+package org.swmaestro.mohaeng.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.swmaestro.mohaeng.domain.Location;
+import org.swmaestro.mohaeng.domain.shop.ShopDetail;
+import org.swmaestro.mohaeng.domain.user.User;
+import org.swmaestro.mohaeng.dto.shop.ShopDetailListRequestDto;
+import org.swmaestro.mohaeng.repository.ShopDetailRepository;
+import org.swmaestro.mohaeng.repository.UserRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ShopDetailService {
+
+    private static final int RADIUS = 1000;
+
+    private final UserRepository userRepository;
+    private final ShopDetailRepository shopDetailRepository;
+
+    public List<ShopDetailListRequestDto> getShopDetailsNearBy(Long userId) {
+        Location userLocation = getUserPrimaryLocation(userId);
+        List<ShopDetail> shopDetails = shopDetailRepository.findShopsWithinRadius(
+                userLocation.getLongitude(),
+                userLocation.getLatitude(),
+                RADIUS
+        );
+
+        return shopDetails.stream()
+                .map(shopDetail -> ShopDetailListRequestDto.of(shopDetail))
+                .collect(Collectors.toList());
+    }
+
+    private Location getUserPrimaryLocation(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+        return user.getPrimaryLocation();
+    }
+}


### PR DESCRIPTION
## 작업 목록
- [x] 사용자 위치 기반 주변 행사 상점 조회 기능 구현

## 세부 내용
- ShopDetailRepository: 사용자 위치 기반으로 지정된 반경 내의 상점을 찾기 위해 ST_DISTANCE_SPHERE를 사용하는 네이티브 SQL 쿼리를 포함하는 커스텀 JPA 리포지토리 메소드 findShopsWithinRadius가 추가되었습니다.
- ShopDetailService: 사용자의 기본 위치를 검색하고 리포지토리 메소드를 사용하여 주변 상점 세부 정보를 가져오는 getShopDetailsNearBy 메소드가 포함되어 있습니다.
- ShopDetailController: 인증된 사용자의 위치를 기반으로 주변 상점 세부 정보를 제공하는 기능을 사용하여 GET /shops/nearby라는 새로운 엔드포인트가 추가되었습니다.

## 논의 사항
- 행사 진행하지 않는 상점들에 대해서 조회할 때 행사 리스트 함께 조회한 후 진행하는 상점들만 필터링할지 status column에 행사가 종료되면 값을 바꿔줄지에 대해서 고민해봐야 할 것 같습니다!
- 상점 밀도가 높은 지역에서의 잠재적 성능 문제 및 최적화 가능성. 

## 연결된 이슈
- #58 