### PR TITLE
[Resolves #62] 매장 상세 정보 기능 구현

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/controller/ShopDetailController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/ShopDetailController.java
@@ -5,9 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.swmaestro.mohaeng.domain.user.auth.CustomUserDetails;
+import org.swmaestro.mohaeng.dto.shop.ShopDetailResponseDto;
 import org.swmaestro.mohaeng.dto.shop.ShopDetailListRequestDto;
 import org.swmaestro.mohaeng.service.ShopDetailService;
 
@@ -28,5 +30,11 @@ public class ShopDetailController {
         List<ShopDetailListRequestDto> shopDetails = shopDetailService.getShopDetailsNearBy(userId);
         log.info("Number of shops found: {}", shopDetails.size());
         return ResponseEntity.ok(shopDetails);
+    }
+
+    @GetMapping("/{shopDetailId}")
+    public ResponseEntity<ShopDetailResponseDto> getShopDetail(@PathVariable Long shopDetailId) {
+        ShopDetailResponseDto shopDetailResponseDto = shopDetailService.getShopDetail(shopDetailId);
+        return ResponseEntity.ok(shopDetailResponseDto);
     }
 }

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/Event.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/Event.java
@@ -33,7 +33,7 @@ public class Event extends BaseTimeEntity {
     private String categoryCode;
 
     @Enumerated(EnumType.STRING)
-    private EventDetails eventDetails;
+    private EventType eventType;
 
     @Column(name = "event_regular_price", nullable = false)
     private int regularPrice;
@@ -71,10 +71,10 @@ public class Event extends BaseTimeEntity {
     private Status status;
 
     @Builder
-    public Event(Shop shop, String categoryCode, EventDetails eventDetails, int regularPrice, int discountPrice, String name, String description, String imageUrl, String startDate, String endDate, String startTime, String endTime, CreatedBy createdBy, Status status) {
+    public Event(Shop shop, String categoryCode, EventType eventType, int regularPrice, int discountPrice, String name, String description, String imageUrl, String startDate, String endDate, String startTime, String endTime, CreatedBy createdBy, Status status) {
         this.shop = shop;
         this.categoryCode = categoryCode;
-        this.eventDetails = eventDetails;
+        this.eventType = eventType;
         this.regularPrice = regularPrice;
         this.discountPrice = discountPrice;
         this.name = name;

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/EventDetails.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/EventDetails.java
@@ -1,5 +1,0 @@
-package org.swmaestro.mohaeng.domain.event;
-
-public enum EventDetails {
-    ONE_PLUS_ONE, TWO_PLUS_ONE, PRICE_DISCOUNT, COUPON, ETC
-}

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/EventType.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/EventType.java
@@ -1,0 +1,20 @@
+package org.swmaestro.mohaeng.domain.event;
+
+public enum EventType {
+    ONE_PLUS_ONE("1+1"),
+    TWO_PLUS_ONE("2+1"),
+    PRICE_DISCOUNT("가격할인"),
+    GIFT("사은품증정"),
+    COUPON("쿠폰"),
+    ETC("기타");
+
+    private final String value;
+
+    private EventType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/EventTypeConverter.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/EventTypeConverter.java
@@ -1,0 +1,32 @@
+package org.swmaestro.mohaeng.domain.event;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class EventTypeConverter implements AttributeConverter<EventType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(EventType eventType) {
+        if (eventType == null) {
+            return null;
+        }
+        return eventType.getValue();
+    }
+
+    @Override
+    public EventType convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+
+        for (EventType eventType : EventType.values()) {
+            if (eventType.getValue().equals(dbData)) {
+                return eventType;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown value: " + dbData);
+    }
+}
+

--- a/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailListRequestDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailListRequestDto.java
@@ -9,30 +9,30 @@ import org.swmaestro.mohaeng.domain.shop.ShopType;
 public class ShopDetailListRequestDto {
 
     private final Long id;
+    private final String name;
     private final ShopType shopType;
     private final String brandCode;
     private final double latitude;
     private final double longitude;
-    private final String imageUrl;
 
     @Builder
-    public ShopDetailListRequestDto(Long id, ShopType shopType, String brandCode, double latitude, double longitude, String imageUrl) {
+    public ShopDetailListRequestDto(Long id, String name, ShopType shopType, String brandCode, double latitude, double longitude) {
         this.id = id;
+        this.name = name;
         this.shopType = shopType;
         this.brandCode = brandCode;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.imageUrl = imageUrl;
     }
 
     public static ShopDetailListRequestDto of(ShopDetail shopDetail) {
         return ShopDetailListRequestDto.builder()
                 .id(shopDetail.getId())
+                .name(shopDetail.getName())
                 .shopType(shopDetail.getShop().getShopType())
                 .brandCode(shopDetail.getShop().getBrandCode())
                 .latitude(shopDetail.getLatitude())
                 .longitude(shopDetail.getLongitude())
-                .imageUrl(shopDetail.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailResponseDto.java
@@ -1,0 +1,50 @@
+package org.swmaestro.mohaeng.dto.shop;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.swmaestro.mohaeng.domain.event.EventType;
+import org.swmaestro.mohaeng.domain.shop.ShopDetail;
+import org.swmaestro.mohaeng.domain.shop.ShopType;
+
+import java.util.Set;
+
+@Getter
+public class ShopDetailResponseDto {
+
+    private final Long id;
+    private final String name;
+    private final ShopType shopType;
+    private final String brandCode;
+    private final double latitude;
+    private final double longitude;
+    private final String imageUrl;
+    private final Long eventCount;
+    private final Set<EventType> eventDetails;
+
+    @Builder
+    public ShopDetailResponseDto(Long id, String name, ShopType shopType, String brandCode, double latitude, double longitude, String imageUrl, Long eventCount, Set<EventType> eventDetails) {
+        this.id = id;
+        this.name = name;
+        this.shopType = shopType;
+        this.brandCode = brandCode;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.imageUrl = imageUrl;
+        this.eventCount = eventCount;
+        this.eventDetails = eventDetails;
+    }
+
+    public static ShopDetailResponseDto of(ShopDetail shopDetail, Long eventCount, Set<EventType> eventDetails) {
+        return ShopDetailResponseDto.builder()
+                .id(shopDetail.getId())
+                .name(shopDetail.getName())
+                .shopType(shopDetail.getShop().getShopType())
+                .brandCode(shopDetail.getShop().getBrandCode())
+                .latitude(shopDetail.getLatitude())
+                .longitude(shopDetail.getLongitude())
+                .imageUrl(shopDetail.getImageUrl())
+                .eventCount(eventCount)
+                .eventDetails(eventDetails)
+                .build();
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/repository/EventRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/EventRepository.java
@@ -1,0 +1,22 @@
+package org.swmaestro.mohaeng.repository;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.swmaestro.mohaeng.domain.event.Event;
+import org.swmaestro.mohaeng.domain.event.EventType;
+
+import java.util.Set;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Query("SELECT COUNT(e) " +
+            "FROM Event e " +
+            "WHERE e.shop.id = (SELECT sd.shop.id " +
+            "FROM ShopDetail sd " +
+            "WHERE sd.id = :shopDetailId)")
+    Long countByShopDetail(@Param("shopDetailId") Long shopDetailId);
+
+    @Query("SELECT DISTINCT e.eventType FROM Event e WHERE e.shop.id = (SELECT sd.shop.id FROM ShopDetail sd WHERE sd.id = :shopDetailId)")
+    Set<EventType> findDistinctEventDetailsByShopDetailId(@Param("shopDetailId") Long shopDetailId);
+}

--- a/src/main/java/org/swmaestro/mohaeng/service/ShopDetailService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/ShopDetailService.java
@@ -3,14 +3,19 @@ package org.swmaestro.mohaeng.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.swmaestro.mohaeng.domain.Location;
+import org.swmaestro.mohaeng.domain.event.EventType;
 import org.swmaestro.mohaeng.domain.shop.ShopDetail;
 import org.swmaestro.mohaeng.domain.user.User;
 import org.swmaestro.mohaeng.dto.shop.ShopDetailListRequestDto;
+import org.swmaestro.mohaeng.dto.shop.ShopDetailResponseDto;
+import org.swmaestro.mohaeng.repository.EventRepository;
 import org.swmaestro.mohaeng.repository.ShopDetailRepository;
 import org.swmaestro.mohaeng.repository.UserRepository;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -21,8 +26,10 @@ public class ShopDetailService {
     private static final int RADIUS = 1000;
 
     private final UserRepository userRepository;
+    private final EventRepository eventRepository;
     private final ShopDetailRepository shopDetailRepository;
 
+    @Transactional(readOnly = true)
     public List<ShopDetailListRequestDto> getShopDetailsNearBy(Long userId) {
         Location userLocation = getUserPrimaryLocation(userId);
         List<ShopDetail> shopDetails = shopDetailRepository.findShopsWithinRadius(
@@ -40,5 +47,14 @@ public class ShopDetailService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
         return user.getPrimaryLocation();
+    }
+
+    @Transactional(readOnly = true)
+    public ShopDetailResponseDto getShopDetail(Long shopDetailId) {
+        ShopDetail shopDetail = shopDetailRepository.findById(shopDetailId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 없습니다."));
+        Long eventCount = eventRepository.countByShopDetail(shopDetailId);
+        Set<EventType> eventDetails = eventRepository.findDistinctEventDetailsByShopDetailId(shopDetailId);
+        return ShopDetailResponseDto.of(shopDetail, eventCount, eventDetails);
     }
 }


### PR DESCRIPTION
## 작업 목록
- [x] 상점 상세 정보와 함께 해당 상점에서 진행 중인 행사의 개수 및 종류를 조회할 수 있도록 구현.

## 세부 내용
- EventRepository에 이벤트 카운트 및 이벤트 종류 조회를 위한 메소드 추가.
- ShopDetailService에서 이벤트 정보와 상점 상세 정보를 결합하여 ShopDetailResponseDto 형태로 반환.
- 새로운 API 엔드포인트 GET /shop-details/{shopDetailId}를 통해 해당 기능 제공.

## 논의 사항
- EventRepository에서 현재는 각각 이벤트 개수를 계산하는 쿼리와 이벤트 종류를 조회하는 쿼리가 따로 나가게되는데 성능 최적화 부분 고민 필요할 듯 합니다.

## 연결된 이슈
- #62 