### PR TITLE
[Hotfix] Event 엔티티의 EventType Enum 매핑 문제 수정

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/domain/event/Event.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/Event.java
@@ -32,7 +32,7 @@ public class Event extends BaseTimeEntity {
     @Column(name = "category_code", nullable = false, length = 45)
     private String categoryCode;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = EventTypeConverter.class)
     private EventType eventType;
 
     @Column(name = "event_regular_price", nullable = false)

--- a/src/main/java/org/swmaestro/mohaeng/repository/EventRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/EventRepository.java
@@ -1,8 +1,8 @@
 package org.swmaestro.mohaeng.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.swmaestro.mohaeng.domain.event.Event;
 import org.swmaestro.mohaeng.domain.event.EventType;
 


### PR DESCRIPTION
## 작업 목록
- [x] Event 엔티티의 EventType Enum 매핑 문제 수정

## 세부 내용
- `Event` 엔티티에서 `EventType` enum이 데이터베이스의 문자열 값과 올바르게 매핑되지 않는 문제가 발견되었습니다. 이는 `@Enumerated(EnumType.STRING)` 어노테이션을 사용하여 enum의 이름을 문자열로 저장하고 있었기 때문입니다.
- `EventType` enum과 데이터베이스 간의 매핑을 올바르게 처리하기 위해 `@Enumerated(EnumType.STRING)`를 제거하고, `EventTypeConverter` 클래스를 사용하여 매핑을 처리하도록 수정했습니다.

## 논의 사항

## 연결된 이슈