### PR TITLE
[Resolves #65] 매장 행사 상품 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/controller/EventController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/EventController.java
@@ -1,0 +1,28 @@
+package org.swmaestro.mohaeng.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swmaestro.mohaeng.dto.EventsByShopDetailResponseDto;
+import org.swmaestro.mohaeng.service.EventService;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/events")
+@RestController
+public class EventController {
+
+    private final EventService eventService;
+
+    @GetMapping("/shops/{shopDetailId}")
+    public ResponseEntity<Page<EventsByShopDetailResponseDto>> getEventsByShopDetail(@PathVariable Long shopDetailId, Pageable pageable) {
+        Page<EventsByShopDetailResponseDto> events = eventService.getEventsByShopDetail(shopDetailId, pageable);
+        return ResponseEntity.ok(events);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/domain/event/EventType.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/event/EventType.java
@@ -1,5 +1,8 @@
 package org.swmaestro.mohaeng.domain.event;
 
+import lombok.Getter;
+
+@Getter
 public enum EventType {
     ONE_PLUS_ONE("1+1"),
     TWO_PLUS_ONE("2+1"),
@@ -12,9 +15,5 @@ public enum EventType {
 
     private EventType(String value) {
         this.value = value;
-    }
-
-    public String getValue() {
-        return value;
     }
 }

--- a/src/main/java/org/swmaestro/mohaeng/dto/EventsByShopDetailResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/EventsByShopDetailResponseDto.java
@@ -1,0 +1,44 @@
+package org.swmaestro.mohaeng.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.swmaestro.mohaeng.domain.event.Event;
+import org.swmaestro.mohaeng.domain.event.EventType;
+
+
+
+@Getter
+public class EventsByShopDetailResponseDto {
+
+    private Long id;
+    private String name;
+    private String categoryCode;
+    private EventType eventType;
+    private int regularPrice;
+    private int discountPrice;
+    private String imageUrl;
+
+    @Builder
+    public EventsByShopDetailResponseDto(Long id, String name, String categoryCode, EventType eventType, int regularPrice, int discountPrice, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.categoryCode = categoryCode;
+        this.eventType = eventType;
+        this.regularPrice = regularPrice;
+        this.discountPrice = discountPrice;
+        this.imageUrl = imageUrl;
+    }
+
+    public static EventsByShopDetailResponseDto of(Event event) {
+        return EventsByShopDetailResponseDto.builder()
+                .id(event.getId())
+                .name(event.getName())
+                .categoryCode(event.getCategoryCode())
+                .eventType(event.getEventType())
+                .regularPrice(event.getRegularPrice())
+                .discountPrice(event.getDiscountPrice())
+                .imageUrl(event.getImageUrl())
+                .build();
+    }
+
+}

--- a/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailResponseDto.java
@@ -7,6 +7,7 @@ import org.swmaestro.mohaeng.domain.shop.ShopDetail;
 import org.swmaestro.mohaeng.domain.shop.ShopType;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 public class ShopDetailResponseDto {
@@ -19,7 +20,7 @@ public class ShopDetailResponseDto {
     private final double longitude;
     private final String imageUrl;
     private final Long eventCount;
-    private final Set<EventType> eventTypes;
+    private final Set<String> eventTypes;
 
     @Builder
     public ShopDetailResponseDto(Long id, String name, ShopType shopType, String brandCode, double latitude, double longitude, String imageUrl, Long eventCount, Set<EventType> eventTypes) {
@@ -31,7 +32,9 @@ public class ShopDetailResponseDto {
         this.longitude = longitude;
         this.imageUrl = imageUrl;
         this.eventCount = eventCount;
-        this.eventTypes = eventTypes;
+        this.eventTypes = eventTypes.stream()
+                .map(EventType::getValue)
+                .collect(Collectors.toSet());
     }
 
     public static ShopDetailResponseDto of(ShopDetail shopDetail, Long eventCount, Set<EventType> eventTypes) {

--- a/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/shop/ShopDetailResponseDto.java
@@ -19,10 +19,10 @@ public class ShopDetailResponseDto {
     private final double longitude;
     private final String imageUrl;
     private final Long eventCount;
-    private final Set<EventType> eventDetails;
+    private final Set<EventType> eventTypes;
 
     @Builder
-    public ShopDetailResponseDto(Long id, String name, ShopType shopType, String brandCode, double latitude, double longitude, String imageUrl, Long eventCount, Set<EventType> eventDetails) {
+    public ShopDetailResponseDto(Long id, String name, ShopType shopType, String brandCode, double latitude, double longitude, String imageUrl, Long eventCount, Set<EventType> eventTypes) {
         this.id = id;
         this.name = name;
         this.shopType = shopType;
@@ -31,10 +31,10 @@ public class ShopDetailResponseDto {
         this.longitude = longitude;
         this.imageUrl = imageUrl;
         this.eventCount = eventCount;
-        this.eventDetails = eventDetails;
+        this.eventTypes = eventTypes;
     }
 
-    public static ShopDetailResponseDto of(ShopDetail shopDetail, Long eventCount, Set<EventType> eventDetails) {
+    public static ShopDetailResponseDto of(ShopDetail shopDetail, Long eventCount, Set<EventType> eventTypes) {
         return ShopDetailResponseDto.builder()
                 .id(shopDetail.getId())
                 .name(shopDetail.getName())
@@ -44,7 +44,7 @@ public class ShopDetailResponseDto {
                 .longitude(shopDetail.getLongitude())
                 .imageUrl(shopDetail.getImageUrl())
                 .eventCount(eventCount)
-                .eventDetails(eventDetails)
+                .eventTypes(eventTypes)
                 .build();
     }
 }

--- a/src/main/java/org/swmaestro/mohaeng/repository/EventRepository.java
+++ b/src/main/java/org/swmaestro/mohaeng/repository/EventRepository.java
@@ -1,5 +1,7 @@
 package org.swmaestro.mohaeng.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +21,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("SELECT DISTINCT e.eventType FROM Event e WHERE e.shop.id = (SELECT sd.shop.id FROM ShopDetail sd WHERE sd.id = :shopDetailId)")
     Set<EventType> findDistinctEventDetailsByShopDetailId(@Param("shopDetailId") Long shopDetailId);
+
+    @Query("SELECT e FROM Event e WHERE e.shop.id = (SELECT sd.shop.id FROM ShopDetail sd WHERE sd.id = :shopDetailId)")
+    Page<Event> findByShopDetailIdWithPagination(@Param("shopDetailId") Long shopDetailId, Pageable pageable);
 }

--- a/src/main/java/org/swmaestro/mohaeng/service/EventService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/EventService.java
@@ -1,0 +1,23 @@
+package org.swmaestro.mohaeng.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.swmaestro.mohaeng.dto.EventsByShopDetailResponseDto;
+import org.swmaestro.mohaeng.repository.EventRepository;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    public Page<EventsByShopDetailResponseDto> getEventsByShopDetail(Long shopDetailId, Pageable pageable) {
+        return eventRepository.findByShopDetailIdWithPagination(shopDetailId, pageable)
+                .map(event -> EventsByShopDetailResponseDto.of(event));
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/service/ShopDetailService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/ShopDetailService.java
@@ -54,7 +54,7 @@ public class ShopDetailService {
         ShopDetail shopDetail = shopDetailRepository.findById(shopDetailId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 가게가 없습니다."));
         Long eventCount = eventRepository.countByShopDetail(shopDetailId);
-        Set<EventType> eventDetails = eventRepository.findDistinctEventDetailsByShopDetailId(shopDetailId);
-        return ShopDetailResponseDto.of(shopDetail, eventCount, eventDetails);
+        Set<EventType> eventTypes = eventRepository.findDistinctEventDetailsByShopDetailId(shopDetailId);
+        return ShopDetailResponseDto.of(shopDetail, eventCount, eventTypes);
     }
 }

--- a/src/test/java/org/swmaestro/mohaeng/domain/event/EventTypeConverterTest.java
+++ b/src/test/java/org/swmaestro/mohaeng/domain/event/EventTypeConverterTest.java
@@ -1,0 +1,41 @@
+package org.swmaestro.mohaeng.domain.event;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventTypeConverterTest {
+
+    private final EventTypeConverter converter = new EventTypeConverter();
+    
+    @Test
+    void convertToDatabaseColumn() {
+        assertEquals("1+1", converter.convertToDatabaseColumn(EventType.ONE_PLUS_ONE));
+        assertEquals("2+1", converter.convertToDatabaseColumn(EventType.TWO_PLUS_ONE));
+        assertEquals("가격할인", converter.convertToDatabaseColumn(EventType.PRICE_DISCOUNT));
+        assertEquals("사은품증정", converter.convertToDatabaseColumn(EventType.GIFT));
+        assertEquals("쿠폰", converter.convertToDatabaseColumn(EventType.COUPON));
+        assertEquals("기타", converter.convertToDatabaseColumn(EventType.ETC));
+    }
+
+    @Test
+    void convertToEntityAttribute() {
+        assertEquals(EventType.ONE_PLUS_ONE, converter.convertToEntityAttribute("1+1"));
+        assertEquals(EventType.TWO_PLUS_ONE, converter.convertToEntityAttribute("2+1"));
+        assertEquals(EventType.PRICE_DISCOUNT, converter.convertToEntityAttribute("가격할인"));
+        assertEquals(EventType.GIFT, converter.convertToEntityAttribute("사은품증정"));
+        assertEquals(EventType.COUPON, converter.convertToEntityAttribute("쿠폰"));
+        assertEquals(EventType.ETC, converter.convertToEntityAttribute("기타"));
+    }
+
+    @Test
+    void convertNull() {
+        assertNull(converter.convertToDatabaseColumn(null));
+        assertNull(converter.convertToEntityAttribute(null));
+    }
+
+    @Test
+    void shouldThrowExceptionForUnknownValue() {
+        assertThrows(IllegalArgumentException.class, () -> converter.convertToEntityAttribute("Unknown"));
+    }
+}


### PR DESCRIPTION
## 작업 목록
- [x] 매장에서 진행하는 행사 상품 조회 기능 구현
- [x]  페이징 및 정렬 기능 구현

## 세부 내용
- EventRepository: ShopDetailId를 기반으로 행사 상품을 조회하는 페이징 및 정렬 기능을 가진 쿼리 메소드 findByShopDetailIdWithPagination를 추가했습니다.
- EventService: 페이징 처리된 행사 상품 데이터를 가져오고, 비즈니스 로직을 처리하는 getEventsByShopDetail 메소드를 구현했습니다.
- EventController: 클라이언트의 요청에 대한 엔드포인트 GET /events/shop-detail/{shopDetailId}를 구현하여, EventService를 통해 데이터를 제공합니다.

## 논의 사항

## 연결된 이슈
- #65 