### PR TITLE
[Resolves #67] 등록된 위치 정보 수정 기능 구현

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/controller/LocationController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/LocationController.java
@@ -10,10 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.swmaestro.mohaeng.domain.user.User;
 import org.swmaestro.mohaeng.domain.user.auth.CustomUserDetails;
-import org.swmaestro.mohaeng.dto.location.LocationCreateRequestDto;
-import org.swmaestro.mohaeng.dto.location.LocationCreateResponseDto;
-import org.swmaestro.mohaeng.dto.location.LocationDetailResponseDto;
-import org.swmaestro.mohaeng.dto.location.LocationListResponseDto;
+import org.swmaestro.mohaeng.dto.location.*;
 import org.swmaestro.mohaeng.service.LocationService;
 
 import javax.validation.Valid;
@@ -86,6 +83,20 @@ public class LocationController {
         log.info("ID: {}인 위치를 주 위치로 설정 중", locationId);
         locationService.setPrimaryLocation(userId, locationId);
         return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{locationId}")
+    public ResponseEntity<LocationDetailResponseDto> updateLocation(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                    @PathVariable Long locationId,
+                                                                    @Valid @RequestBody LocationUpdateRequestDto locationUpdateRequestDto) {
+        Long userId = userDetails.getUserId();
+        log.info("userId: {}", userId);
+        validateUser(userId);
+
+        log.info("Updating locationId: {}", locationId);
+        LocationDetailResponseDto updatedLocation = locationService.updateLocation(userId, locationId, locationUpdateRequestDto);
+
+        return ResponseEntity.ok(updatedLocation);
     }
 
     private static void validateUser(Long userId) {

--- a/src/main/java/org/swmaestro/mohaeng/domain/Location.java
+++ b/src/main/java/org/swmaestro/mohaeng/domain/Location.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.swmaestro.mohaeng.domain.user.User;
+import org.swmaestro.mohaeng.dto.location.LocationUpdateRequestDto;
 
 import javax.persistence.*;
 
@@ -29,16 +30,16 @@ public class Location extends BaseTimeEntity {
     private String address;
 
     @Column(name = "latitude", nullable = false)
-    private double latitude;
+    private Double latitude;
 
     @Column(name = "longitude", nullable = false)
-    private double longitude;
+    private Double longitude;
 
     @Column(name = "is_primary", nullable = false)
     private Boolean isPrimary;
 
     @Builder
-    public Location(User user, String name, String address, double latitude, double longitude, Boolean isPrimary) {
+    public Location(User user, String name, String address, Double latitude, Double longitude, Boolean isPrimary) {
         this.user = user;
         this.name = name;
         this.address = address;
@@ -47,7 +48,7 @@ public class Location extends BaseTimeEntity {
         this.isPrimary = isPrimary;
     }
 
-    public static Location of(User user, String name, String address, double latitude, double longitude, boolean isPrimary) {
+    public static Location of(User user, String name, String address, Double latitude, Double longitude, Boolean isPrimary) {
         return Location.builder()
                 .user(user)
                 .name(name)
@@ -68,5 +69,20 @@ public class Location extends BaseTimeEntity {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public void update(LocationUpdateRequestDto updateRequestDto) {
+        if (updateRequestDto.getName() != null) {
+            this.name = updateRequestDto.getName();
+        }
+        if (updateRequestDto.getAddress() != null) {
+            this.address = updateRequestDto.getAddress();
+        }
+        if (updateRequestDto.getLatitude() != null) {
+            this.latitude = updateRequestDto.getLatitude();
+        }
+        if (updateRequestDto.getLongitude() != null) {
+            this.longitude = updateRequestDto.getLongitude();
+        }
     }
 }

--- a/src/main/java/org/swmaestro/mohaeng/dto/location/LocationCreateRequestDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/location/LocationCreateRequestDto.java
@@ -23,10 +23,12 @@ public class LocationCreateRequestDto {
     @NotBlank(message = "주소를 입력해주세요.")
     private String address;
 
+    @NotNull(message = "위도를 입력해주세요.")
     @DecimalMin(value = "33.0", message = "위도는 최소 33.0 이상이어야 합니다.")
     @DecimalMax(value = "38.0", message = "위도는 최대 38.0 이하여야 합니다.")
     private double latitude;
 
+    @NotNull(message = "경도를 입력해주세요.")
     @DecimalMin(value = "124.0", message = "경도는 최소 124.0 이상이어야 합니다.")
     @DecimalMax(value = "132.0", message = "경도는 최대 132.0 이하여야 합니다.")
     private double longitude;

--- a/src/main/java/org/swmaestro/mohaeng/dto/location/LocationCreateResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/location/LocationCreateResponseDto.java
@@ -10,12 +10,12 @@ public class LocationCreateResponseDto {
     private Long id;
     private String name;
     private String address;
-    private double latitude;
-    private double longitude;
-    private boolean isPrimary;
+    private Double latitude;
+    private Double longitude;
+    private Boolean isPrimary;
 
     @Builder
-    public LocationCreateResponseDto(Long id, String name, String address, double latitude, double longitude, boolean isPrimary) {
+    public LocationCreateResponseDto(Long id, String name, String address, Double latitude, Double longitude, Boolean isPrimary) {
         this.id = id;
         this.name = name;
         this.address = address;

--- a/src/main/java/org/swmaestro/mohaeng/dto/location/LocationDetailResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/location/LocationDetailResponseDto.java
@@ -11,8 +11,8 @@ public class LocationDetailResponseDto {
     private Long id;
     private String name;
     private String address;
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
     private boolean isPrimary;
 
     public static LocationDetailResponseDto of(Location location) {

--- a/src/main/java/org/swmaestro/mohaeng/dto/location/LocationUpdateRequestDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/location/LocationUpdateRequestDto.java
@@ -1,0 +1,26 @@
+package org.swmaestro.mohaeng.dto.location;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LocationUpdateRequestDto {
+
+    private String name;
+
+    private String address;
+
+    @DecimalMin(value = "33.0", message = "위도는 최소 33.0 이상이어야 합니다.")
+    @DecimalMax(value = "38.0", message = "위도는 최대 38.0 이하여야 합니다.")
+    private Double latitude;
+
+    @DecimalMin(value = "124.0", message = "경도는 최소 124.0 이상이어야 합니다.")
+    @DecimalMax(value = "132.0", message = "경도는 최대 132.0 이하여야 합니다.")
+    private Double longitude;
+}

--- a/src/main/java/org/swmaestro/mohaeng/service/LocationService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/LocationService.java
@@ -7,12 +7,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import org.swmaestro.mohaeng.dto.location.LocationDetailResponseDto;
-import org.swmaestro.mohaeng.dto.location.LocationListResponseDto;
+import org.swmaestro.mohaeng.dto.location.*;
 import org.swmaestro.mohaeng.domain.Location;
 import org.swmaestro.mohaeng.domain.user.User;
-import org.swmaestro.mohaeng.dto.location.LocationCreateRequestDto;
-import org.swmaestro.mohaeng.dto.location.LocationCreateResponseDto;
 import org.swmaestro.mohaeng.repository.LocationRepository;
 import org.swmaestro.mohaeng.repository.UserRepository;
 
@@ -104,4 +101,21 @@ public class LocationService {
         userRepository.save(user);
     }
 
+    @Transactional
+    public LocationDetailResponseDto updateLocation(Long userId, Long locationId, LocationUpdateRequestDto locationUpdateRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "위치를 찾을 수 없습니다."));
+
+        if (!location.getUser().equals(user)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "이 위치를 수정할 권한이 없습니다.");
+        }
+
+        location.update(locationUpdateRequestDto);
+
+        Location updatedLocation = locationRepository.save(location);
+        return LocationDetailResponseDto.of(updatedLocation);
+    }
 }


### PR DESCRIPTION
## 작업 목록
- [x] `Location` 엔티티와 관련된 DTO에 위치 정보 수정 기능 추가
- [x] `LocationService`에 `updateLocation` 메서드 구현
- [x] 위치 정보 수정 API 구현 및 UI 업데이트
- [x] 사용자 인증 및 권한 확인 로직 구현
- [x] 위치 정보의 부분 업데이트 지원을 위한 DTO 수정

## 세부 내용
- `Location` 엔티티와 관련된 DTO, 서비스, 컨트롤러에 위치 정보 수정 기능을 추가하여 사용자가 이름, 주소, 위도, 경도를 수정할 수 있게 하였습니다.
- `LocationService` 내 `updateLocation` 메서드에 사용자 인증 및 권한 확인 로직을 추가하여 위치 정보의 소유자만이 수정할 수 있도록 구현하였습니다.
- DTO 필드를 `Double` 타입으로 변경하여 `null` 값을 체크할 수 있게 함으로써 부분 업데이트가 가능하도록 개선했습니다.

## 논의 사항
- 위치 정보 수정 후 사용자에게 실시간 피드백을 제공하는 기능의 필요성에 대해 논의가 필요

## 연결된 이슈
- #67 