### PR TITLE
[Resolves #71] 행사 상품 상세 조회 기능 구현

### DIFF
--- a/src/main/java/org/swmaestro/mohaeng/controller/EventController.java
+++ b/src/main/java/org/swmaestro/mohaeng/controller/EventController.java
@@ -14,6 +14,7 @@ import org.swmaestro.mohaeng.domain.Location;
 import org.swmaestro.mohaeng.domain.user.User;
 import org.swmaestro.mohaeng.domain.user.auth.CustomUserDetails;
 import org.swmaestro.mohaeng.dto.EventListResponseDto;
+import org.swmaestro.mohaeng.dto.EventResponseDto;
 import org.swmaestro.mohaeng.service.EventService;
 
 @Slf4j
@@ -38,5 +39,11 @@ public class EventController {
 
         Page<EventListResponseDto> events = eventService.getAllEvents(userLocation, pageable);
         return ResponseEntity.ok(events);
+    }
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long eventId) {
+        EventResponseDto event = eventService.getEventById(eventId);
+        return ResponseEntity.ok(event);
     }
 }

--- a/src/main/java/org/swmaestro/mohaeng/dto/EventResponseDto.java
+++ b/src/main/java/org/swmaestro/mohaeng/dto/EventResponseDto.java
@@ -1,0 +1,38 @@
+package org.swmaestro.mohaeng.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.swmaestro.mohaeng.domain.event.Event;
+import org.swmaestro.mohaeng.domain.event.EventType;
+
+@Getter
+public class EventResponseDto {
+
+    private Long id;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private int regularPrice;
+    private int discountPrice;
+    private String startDate;
+    private String endDate;
+    private String categoryCode;
+    private EventType eventType;
+
+    public EventResponseDto(Event event) {
+        this.id = event.getId();
+        this.name = event.getName();
+        this.description = event.getDescription();
+        this.imageUrl = event.getImageUrl();
+        this.regularPrice = event.getRegularPrice();
+        this.discountPrice = event.getDiscountPrice();
+        this.startDate = event.getStartDate();
+        this.endDate = event.getEndDate();
+        this.categoryCode = event.getCategoryCode();
+        this.eventType = event.getEventType();
+    }
+
+    public static EventResponseDto of(Event event) {
+        return new EventResponseDto(event);
+    }
+}

--- a/src/main/java/org/swmaestro/mohaeng/service/EventService.java
+++ b/src/main/java/org/swmaestro/mohaeng/service/EventService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.swmaestro.mohaeng.domain.Location;
 import org.swmaestro.mohaeng.domain.shop.Shop;
 import org.swmaestro.mohaeng.dto.EventListResponseDto;
+import org.swmaestro.mohaeng.dto.EventResponseDto;
 import org.swmaestro.mohaeng.repository.EventRepository;
 import org.swmaestro.mohaeng.repository.ShopRepository;
 
@@ -42,5 +43,12 @@ public class EventService {
 
         return eventRepository.findByShopsWithPagination(shops, pageable)
                 .map(event -> EventListResponseDto.of(event));
+    }
+
+    @Transactional(readOnly = true)
+    public EventResponseDto getEventById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .map(event -> EventResponseDto.of(event))
+                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 없습니다."));
     }
 }


### PR DESCRIPTION
## 작업 목록
- [x] 행사 상품 상세 조회 기능 구현

## 세부 내용
- 행사 상품 Id로 행사 상품 상세 조회하는 기능을 구현하였습니다.

## 논의 사항
- 추후 행사를 진행하는 매장 위치 관련해서 기능 추가 및 자주 조회되는 행사 상품을 캐시에 올리는 기능까지 고려해봐야할 것 같습니다.

## 연결된 이슈
- #71 